### PR TITLE
Highlight text token if available

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -11,6 +11,7 @@
 """This module exports the Reek plugin class."""
 
 from SublimeLinter.lint import RubyLinter
+import re
 
 
 class Reek(RubyLinter):
@@ -32,3 +33,27 @@ class Reek(RubyLinter):
     version_re = r'reek\s(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 3.5.0'
     config_file = ('-c', 'config.reek')
+
+    def split_match(self, match):
+        """Extract named capture groups from the regex and return them as a tuple."""
+
+        match, line, col, error, warning, message, _ = super().split_match(match)
+        near = self.search_token(message)
+
+        return match, line, col, error, warning, message, near
+
+    def search_token(self, message):
+        """Search text token to be highlighted."""
+
+        # First search for variable name enclosed in single quotes
+        m = re.search("'.*'", message)
+
+        # If there's no variable name search for nil-check message
+        if m is None:
+            m = re.search('nil(?=-check)', message)
+
+        # If there's no nil-check search for method name that comes after a `#`
+        if m is None:
+            m = re.search('(?<=#)\S+', message)
+
+        return m.group(0) if m else None

--- a/linter.py
+++ b/linter.py
@@ -26,10 +26,9 @@ class Reek(RubyLinter):
         'ruby on rails',
         'ruby'
     )
-    cmd = 'ruby -S reek'
+    cmd = 'reek'
     regex = r'^.+?\[(?P<line>\d+).*\]:(?P<message>.+) \[.*\]'
     tempfile_suffix = 'rb'
-    version_args = '-S reek -v'
     version_re = r'reek\s(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 3.5.0'
     config_file = ('-c', 'config.reek')

--- a/linter.py
+++ b/linter.py
@@ -26,7 +26,7 @@ class Reek(RubyLinter):
         'ruby'
     )
     cmd = 'ruby -S reek'
-    regex = r'^.+?\[(?P<line>\d+).*\]:(?P<message>.+)'
+    regex = r'^.+?\[(?P<line>\d+).*\]:(?P<message>.+) \[.*\]'
     tempfile_suffix = 'rb'
     version_args = '-S reek -v'
     version_re = r'reek\s(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
Since reek does not return column numbers, the best we can do for now is parse the smell messages and highlight the referenced tokens.

Before:
![before token highlight](https://cloud.githubusercontent.com/assets/531168/23331550/112de984-fb60-11e6-85fe-97965c04e2d8.png)

After:
![after token highlight](https://cloud.githubusercontent.com/assets/531168/23331554/228c15a2-fb60-11e6-8070-e30be8fe4da3.png)

I also changed the `cmd` property for no particular reason, but I can revert that if it doesn't make sense.