### PR TITLE
Fix `cmd` for linter

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -26,9 +26,10 @@ class Reek(RubyLinter):
         'ruby on rails',
         'ruby'
     )
-    cmd = 'reek'
+    cmd = 'ruby -S reek'
     regex = r'^.+?\[(?P<line>\d+).*\]:(?P<message>.+) \[.*\]'
     tempfile_suffix = 'rb'
+    version_args = '-S reek -v'
     version_re = r'reek\s(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 3.5.0'
     config_file = ('-c', 'config.reek')


### PR DESCRIPTION
To inherit from the RubyLinter `ruby -S` must be added to any
Ruby based command

Fixes #4 